### PR TITLE
Sidebarコンポーネントを追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { EditCustomWorkouts } from "@/pages/EditCustomWorkouts";
 import { ChangePassword } from "@/pages/ChangePassword";
 import { History } from "@/pages/History";
 import { Layout } from "@/Layout";
+import { paths } from "./services/utils/paths";
 
 function App() {
   return (
@@ -17,21 +18,20 @@ function App() {
       {/* TODO: ログインしていない時はリダイレクトするようProtectedRouteで囲う */}
       <Route path="/" element={<Layout />}>
         <Route index element={<Navigate replace to="/dashboard" />} />
-        <Route path="/dashboard" element={<Home />} />
-        <Route path="/workouts" element={<Workouts />} />
-        <Route path="/workout/:id" element={<Workout />} />
-        <Route path="/mypage" element={<Mypage />} />
-        <Route path="/custom-workouts" element={<CustomWorkouts />} />
-        <Route path="/custom-workouts" element={<CustomWorkouts />} />
+        <Route path={paths.dashboard} element={<Home />} />
+        <Route path={paths.workouts} element={<Workouts />} />
+        <Route path={paths.workout} element={<Workout />} />
+        <Route path={paths.mypage} element={<Mypage />} />
+        <Route path={paths.customWorkouts} element={<CustomWorkouts />} />
         <Route
-          path="/edit/custom-workouts/:id"
+          path={paths.editCustomWorkouts}
           element={<EditCustomWorkouts />}
         />
-        <Route path="/history" element={<History />} />
+        <Route path={paths.history} element={<History />} />
       </Route>
-      <Route path="/signin" element={<Signin />} />
-      <Route path="/signup" element={<Signup />} />
-      <Route path="/change-password" element={<ChangePassword />} />
+      <Route path={paths.signin} element={<Signin />} />
+      <Route path={paths.signup} element={<Signup />} />
+      <Route path={paths.changePassword} element={<ChangePassword />} />
     </Routes>
   );
 }

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -1,10 +1,12 @@
 import { Outlet } from "react-router-dom";
 import { Header } from "@/layouts/Header";
+import { Sidebar } from "./layouts/Sidebar";
 
 export const Layout = () => {
   return (
-    <div>
+    <div className="app-layout">
       <Header />
+      <Sidebar />
       <Outlet />
     </div>
   );

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -1,12 +1,19 @@
 import { Outlet } from "react-router-dom";
 import { Header } from "@/layouts/Header";
 import { Sidebar } from "./layouts/Sidebar";
+import { WhenVisible } from "./components/WhenVisible";
+import { TopDrawer } from "./components/TopDrawer";
 
 export const Layout = () => {
   return (
     <div className="app-layout">
       <Header />
-      <Sidebar />
+      <WhenVisible lg xl>
+        <Sidebar />
+      </WhenVisible>
+      <WhenVisible sm md>
+        <TopDrawer />
+      </WhenVisible>
       <Outlet />
     </div>
   );

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -2,7 +2,6 @@ import { Outlet } from "react-router-dom";
 import { Header } from "@/layouts/Header";
 import { Sidebar } from "./layouts/Sidebar";
 import { WhenVisible } from "./components/WhenVisible";
-import { TopDrawer } from "./components/TopDrawer";
 
 export const Layout = () => {
   return (
@@ -10,9 +9,6 @@ export const Layout = () => {
       <Header />
       <WhenVisible lg xl>
         <Sidebar />
-      </WhenVisible>
-      <WhenVisible sm md>
-        <TopDrawer />
       </WhenVisible>
       <Outlet />
     </div>

--- a/src/components/BurgerMenu/index.tsx
+++ b/src/components/BurgerMenu/index.tsx
@@ -31,8 +31,10 @@ export const BurgerMenu = () => {
               linkTo={item.linkTo}
             />
           ))}
-          <li className={styles.logout}>
-            <UnstyledButton>ログアウト</UnstyledButton>
+          <li>
+            <UnstyledButton className={styles.logout}>
+              ログアウト
+            </UnstyledButton>
           </li>
         </ul>
       </Drawer>

--- a/src/components/BurgerMenu/index.tsx
+++ b/src/components/BurgerMenu/index.tsx
@@ -1,18 +1,8 @@
-import { Burger, Menu } from "@mantine/core";
+import { Burger } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import { MenuDropdownItems } from "../MenuDropdownItems";
 
 export const BurgerMenu = () => {
   const [isMenuOpened, { toggle }] = useDisclosure(false);
 
-  return (
-    <Menu opened={isMenuOpened}>
-      <Menu.Target>
-        <Burger color="brand-blue.7" opened={isMenuOpened} onClick={toggle} />
-      </Menu.Target>
-      <Menu.Dropdown>
-        <MenuDropdownItems />
-      </Menu.Dropdown>
-    </Menu>
-  );
+  return <Burger color="brand-blue.7" opened={isMenuOpened} onClick={toggle} />;
 };

--- a/src/components/BurgerMenu/index.tsx
+++ b/src/components/BurgerMenu/index.tsx
@@ -1,8 +1,41 @@
-import { Burger } from "@mantine/core";
+import { Burger, Drawer, UnstyledButton } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
+import { menuItems } from "@/services/utils/menuItems";
+import { HiOutlineHome } from "react-icons/hi";
+import { HiOutlineSearch } from "react-icons/hi";
+import { HiOutlineViewList } from "react-icons/hi";
+import { HiOutlineUserCircle } from "react-icons/hi";
+import { SideBarItem } from "../SideBarItem";
+import styles from "./styles.module.css";
+
+const drawerItems = [
+  { ...menuItems.dashboard, icon: <HiOutlineHome size={22} /> },
+  { ...menuItems.workouts, icon: <HiOutlineSearch size={22} /> },
+  { ...menuItems.history, icon: <HiOutlineViewList size={22} /> },
+  { ...menuItems.mypage, icon: <HiOutlineUserCircle size={22} /> },
+];
 
 export const BurgerMenu = () => {
-  const [isMenuOpened, { toggle }] = useDisclosure(false);
+  const [isMenuOpened, { toggle, close }] = useDisclosure(false);
 
-  return <Burger color="brand-blue.7" opened={isMenuOpened} onClick={toggle} />;
+  return (
+    <>
+      <Burger color="brand-blue.7" opened={isMenuOpened} onClick={toggle} />
+      <Drawer opened={isMenuOpened} onClose={close}>
+        <ul>
+          {drawerItems.map((item) => (
+            <SideBarItem
+              key={item.linkTo}
+              icon={item.icon}
+              title={item.title}
+              linkTo={item.linkTo}
+            />
+          ))}
+          <li className={styles.logout}>
+            <UnstyledButton>ログアウト</UnstyledButton>
+          </li>
+        </ul>
+      </Drawer>
+    </>
+  );
 };

--- a/src/components/BurgerMenu/styles.module.css
+++ b/src/components/BurgerMenu/styles.module.css
@@ -1,7 +1,13 @@
 .logout {
+  border-radius: 10px;
   color: #f44336;
+  display: block;
   font-size: 0.9rem;
   margin: 13px auto;
   padding: 13px 20px;
   width: 90%;
+}
+
+.logout:hover {
+  background-color: #f3f4f6;
 }

--- a/src/components/BurgerMenu/styles.module.css
+++ b/src/components/BurgerMenu/styles.module.css
@@ -1,0 +1,7 @@
+.logout {
+  color: #f44336;
+  font-size: 0.9rem;
+  margin: 13px auto;
+  padding: 13px 20px;
+  width: 90%;
+}

--- a/src/components/SideBarItem/index.tsx
+++ b/src/components/SideBarItem/index.tsx
@@ -4,18 +4,20 @@ import styles from "./styles.module.css";
 import { NavLink } from "react-router-dom";
 
 type SideBarItemProps = {
-  icon: ReactNode;
+  icon?: ReactNode;
   title: string;
   linkTo: string;
 };
 
 export const SideBarItem = ({ icon, title, linkTo }: SideBarItemProps) => {
   return (
-    <NavLink to={linkTo} className={styles.item}>
-      <Flex gap={7} align={"center"}>
-        {icon}
-        <span>{title}</span>
-      </Flex>
-    </NavLink>
+    <li>
+      <NavLink className={styles.item} to={linkTo}>
+        <Flex gap={7} align={"center"}>
+          {icon}
+          <span>{title}</span>
+        </Flex>
+      </NavLink>
+    </li>
   );
 };

--- a/src/components/SideBarItem/index.tsx
+++ b/src/components/SideBarItem/index.tsx
@@ -1,0 +1,21 @@
+import { Flex } from "@mantine/core";
+import { ReactNode } from "react";
+import styles from "./styles.module.css";
+import { NavLink } from "react-router-dom";
+
+type SideBarItemProps = {
+  icon: ReactNode;
+  title: string;
+  linkTo: string;
+};
+
+export const SideBarItem = ({ icon, title, linkTo }: SideBarItemProps) => {
+  return (
+    <NavLink to={linkTo} className={styles.item}>
+      <Flex gap={7} align={"center"}>
+        {icon}
+        <span>{title}</span>
+      </Flex>
+    </NavLink>
+  );
+};

--- a/src/components/SideBarItem/styles.module.css
+++ b/src/components/SideBarItem/styles.module.css
@@ -5,7 +5,6 @@
   margin: 0 auto;
   text-decoration: none;
   color: #475569;
-  font-weight: 700;
   border-radius: 10px;
 }
 
@@ -13,7 +12,7 @@
   background-color: #f3f4f6;
 }
 
-/* TODO: うまくいっていないので直す */
 .item:global(.active) {
   background-color: #f3f4f6;
+  font-weight: 700;
 }

--- a/src/components/SideBarItem/styles.module.css
+++ b/src/components/SideBarItem/styles.module.css
@@ -1,14 +1,19 @@
 .item {
-  padding: 10px 15px;
+  padding: 13px 20px;
   font-size: 0.9rem;
   width: 90%;
   margin: 0 auto;
   text-decoration: none;
-  color: #030712;
+  color: #475569;
+  font-weight: 700;
+  border-radius: 10px;
+}
+
+.item:hover {
+  background-color: #f3f4f6;
 }
 
 /* TODO: うまくいっていないので直す */
-.item.active {
+.item:global(.active) {
   background-color: #f3f4f6;
-  border-radius: 10px;
 }

--- a/src/components/SideBarItem/styles.module.css
+++ b/src/components/SideBarItem/styles.module.css
@@ -1,11 +1,11 @@
 .item {
-  padding: 13px 20px;
-  font-size: 0.9rem;
-  width: 90%;
-  margin: 0 auto;
-  text-decoration: none;
-  color: #475569;
   border-radius: 10px;
+  color: #475569;
+  display: block;
+  font-size: 0.9rem;
+  margin: 13px auto;
+  padding: 13px 20px;
+  width: 90%;
 }
 
 .item:hover {

--- a/src/components/SideBarItem/styles.module.css
+++ b/src/components/SideBarItem/styles.module.css
@@ -1,0 +1,14 @@
+.item {
+  padding: 10px 15px;
+  font-size: 0.9rem;
+  width: 90%;
+  margin: 0 auto;
+  text-decoration: none;
+  color: #030712;
+}
+
+/* TODO: うまくいっていないので直す */
+.item.active {
+  background-color: #f3f4f6;
+  border-radius: 10px;
+}

--- a/src/global.css
+++ b/src/global.css
@@ -12,6 +12,16 @@
   min-height: 100vh;
 }
 
+ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+a {
+  text-decoration: none;
+}
+
 @media (--md-to-sm) {
   .app-layout {
     grid-template-columns: 1fr;

--- a/src/global.css
+++ b/src/global.css
@@ -25,6 +25,6 @@ a {
 @media (--md-to-sm) {
   .app-layout {
     grid-template-columns: 1fr;
-    grid-template-rows: auto auto 1fr;
+    grid-template-rows: auto 1fr;
   }
 }

--- a/src/global.css
+++ b/src/global.css
@@ -1,6 +1,8 @@
 @custom-media --sm (width <= 48em);
 @custom-media --md (48em < width <= 62em);
+@custom-media --md-to-sm (width <= 62em);
 @custom-media --lg (62em < width <= 75em);
+@custom-media --lg-to-sm (width <= 75em);
 @custom-media --xl (75em < width);
 
 .app-layout {
@@ -8,4 +10,11 @@
   grid-template-columns: 1.25fr 6fr;
   grid-template-rows: auto 1fr;
   min-height: 100vh;
+}
+
+@media (--md-to-sm) {
+  .app-layout {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto 1fr;
+  }
 }

--- a/src/global.css
+++ b/src/global.css
@@ -2,3 +2,10 @@
 @custom-media --md (48em < width <= 62em);
 @custom-media --lg (62em < width <= 75em);
 @custom-media --xl (75em < width);
+
+.app-layout {
+  display: grid;
+  grid-template-columns: 1.25fr 6fr;
+  grid-template-rows: auto 1fr;
+  min-height: 100vh;
+}

--- a/src/layouts/Header/index.tsx
+++ b/src/layouts/Header/index.tsx
@@ -8,10 +8,10 @@ export const Header = () => {
   return (
     <Flex className={styles.header} justify={"space-between"} align={"center"}>
       <h1 className={styles.logo}>Fitness Pal</h1>
-      <WhenVisible sm>
+      <WhenVisible sm md>
         <BurgerMenu />
       </WhenVisible>
-      <WhenVisible md lg xl>
+      <WhenVisible lg xl>
         <IconMenu />
       </WhenVisible>
     </Flex>

--- a/src/layouts/Header/styles.module.css
+++ b/src/layouts/Header/styles.module.css
@@ -16,7 +16,7 @@
   color: var(--mantine-color-brand-blue-7);
 }
 
-@media (--sm) {
+@media (--md) {
   .header {
     padding: 1rem 2rem;
   }

--- a/src/layouts/Header/styles.module.css
+++ b/src/layouts/Header/styles.module.css
@@ -1,7 +1,9 @@
 .header {
+  grid-column: 1 / -1;
   padding: 1rem 4rem;
   background-color: #ffffff;
-  box-shadow: 0 0 2px #e0e0e0;
+  border: 1px solid #e5e7eb;
+  border-width: 0 0 1px;
 }
 
 .header * {

--- a/src/layouts/Header/styles.module.css
+++ b/src/layouts/Header/styles.module.css
@@ -16,7 +16,7 @@
   color: var(--mantine-color-brand-blue-7);
 }
 
-@media (--md) {
+@media (--md-to-sm) {
   .header {
     padding: 1rem 2rem;
   }

--- a/src/layouts/Sidebar/index.tsx
+++ b/src/layouts/Sidebar/index.tsx
@@ -4,37 +4,28 @@ import { HiOutlineSearch } from "react-icons/hi";
 import { HiOutlineViewList } from "react-icons/hi";
 import { HiOutlineUserCircle } from "react-icons/hi";
 import styles from "./styles.module.css";
-import { paths } from "@/services/utils/paths";
+import { menuItems } from "@/services/utils/menuItems";
 
 const sidebarItems = [
-  {
-    icon: <HiOutlineHome size={22} />,
-    title: "ホーム",
-    linkTo: paths.dashboard,
-  },
-  {
-    icon: <HiOutlineSearch size={22} />,
-    title: "トレーニングを探す",
-    linkTo: paths.workouts,
-  },
-  {
-    icon: <HiOutlineViewList size={22} />,
-    title: "トレーニング履歴",
-    linkTo: paths.history,
-  },
-  {
-    icon: <HiOutlineUserCircle size={22} />,
-    title: "マイページ",
-    linkTo: paths.mypage,
-  },
+  { ...menuItems.dashboard, icon: <HiOutlineHome size={22} /> },
+  { ...menuItems.workouts, icon: <HiOutlineSearch size={22} /> },
+  { ...menuItems.history, icon: <HiOutlineViewList size={22} /> },
+  { ...menuItems.mypage, icon: <HiOutlineUserCircle size={22} /> },
 ];
 
 export const Sidebar = () => {
   return (
     <aside className={styles.sidebar}>
-      {sidebarItems.map((item) => (
-        <SideBarItem icon={item.icon} title={item.title} linkTo={item.linkTo} />
-      ))}
+      <ul>
+        {sidebarItems.map((item) => (
+          <SideBarItem
+            key={item.linkTo}
+            icon={item.icon}
+            title={item.title}
+            linkTo={item.linkTo}
+          />
+        ))}
+      </ul>
     </aside>
   );
 };

--- a/src/layouts/Sidebar/index.tsx
+++ b/src/layouts/Sidebar/index.tsx
@@ -6,30 +6,35 @@ import { HiOutlineUserCircle } from "react-icons/hi";
 import styles from "./styles.module.css";
 import { paths } from "@/services/utils/paths";
 
+const sidebarItems = [
+  {
+    icon: <HiOutlineHome size={22} />,
+    title: "ホーム",
+    linkTo: paths.dashboard,
+  },
+  {
+    icon: <HiOutlineSearch size={22} />,
+    title: "トレーニングを探す",
+    linkTo: paths.workouts,
+  },
+  {
+    icon: <HiOutlineViewList size={22} />,
+    title: "トレーニング履歴",
+    linkTo: paths.history,
+  },
+  {
+    icon: <HiOutlineUserCircle size={22} />,
+    title: "マイページ",
+    linkTo: paths.mypage,
+  },
+];
+
 export const Sidebar = () => {
   return (
     <aside className={styles.sidebar}>
-      {/* TODO: パスはcontextとかで共通で持つようにして、そこから取得するようにする */}
-      <SideBarItem
-        icon={<HiOutlineHome size={22} />}
-        title="ホーム"
-        linkTo={paths.dashboard}
-      />
-      <SideBarItem
-        icon={<HiOutlineSearch size={22} />}
-        title="トレーニングを探す"
-        linkTo={paths.workouts}
-      />
-      <SideBarItem
-        icon={<HiOutlineViewList size={22} />}
-        title="トレーニング履歴"
-        linkTo={paths.history}
-      />
-      <SideBarItem
-        icon={<HiOutlineUserCircle size={22} />}
-        title="マイページ"
-        linkTo={paths.mypage}
-      />
+      {sidebarItems.map((item) => (
+        <SideBarItem icon={item.icon} title={item.title} linkTo={item.linkTo} />
+      ))}
     </aside>
   );
 };

--- a/src/layouts/Sidebar/index.tsx
+++ b/src/layouts/Sidebar/index.tsx
@@ -4,31 +4,32 @@ import { HiOutlineSearch } from "react-icons/hi";
 import { HiOutlineViewList } from "react-icons/hi";
 import { HiOutlineUserCircle } from "react-icons/hi";
 import styles from "./styles.module.css";
+import { paths } from "@/services/utils/paths";
 
 export const Sidebar = () => {
   return (
-    <div className={styles.sidebar}>
+    <aside className={styles.sidebar}>
       {/* TODO: パスはcontextとかで共通で持つようにして、そこから取得するようにする */}
       <SideBarItem
         icon={<HiOutlineHome size={22} />}
         title="ホーム"
-        linkTo="/"
+        linkTo={paths.dashboard}
       />
       <SideBarItem
         icon={<HiOutlineSearch size={22} />}
         title="トレーニングを探す"
-        linkTo="/workouts"
+        linkTo={paths.workouts}
       />
       <SideBarItem
         icon={<HiOutlineViewList size={22} />}
         title="トレーニング履歴"
-        linkTo="/history"
+        linkTo={paths.history}
       />
       <SideBarItem
         icon={<HiOutlineUserCircle size={22} />}
         title="マイページ"
-        linkTo="/mypage"
+        linkTo={paths.mypage}
       />
-    </div>
+    </aside>
   );
 };

--- a/src/layouts/Sidebar/index.tsx
+++ b/src/layouts/Sidebar/index.tsx
@@ -1,0 +1,34 @@
+import { SideBarItem } from "@/components/SideBarItem";
+import { HiOutlineHome } from "react-icons/hi";
+import { HiOutlineSearch } from "react-icons/hi";
+import { HiOutlineViewList } from "react-icons/hi";
+import { HiOutlineUserCircle } from "react-icons/hi";
+import styles from "./styles.module.css";
+
+export const Sidebar = () => {
+  return (
+    <div className={styles.sidebar}>
+      {/* TODO: パスはcontextとかで共通で持つようにして、そこから取得するようにする */}
+      <SideBarItem
+        icon={<HiOutlineHome size={22} />}
+        title="ホーム"
+        linkTo="/"
+      />
+      <SideBarItem
+        icon={<HiOutlineSearch size={22} />}
+        title="トレーニングを探す"
+        linkTo="/workouts"
+      />
+      <SideBarItem
+        icon={<HiOutlineViewList size={22} />}
+        title="トレーニング履歴"
+        linkTo="/history"
+      />
+      <SideBarItem
+        icon={<HiOutlineUserCircle size={22} />}
+        title="マイページ"
+        linkTo="/mypage"
+      />
+    </div>
+  );
+};

--- a/src/layouts/Sidebar/styles.module.css
+++ b/src/layouts/Sidebar/styles.module.css
@@ -4,5 +4,5 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  margin-top: 30px;
+  padding-top: 30px;
 }

--- a/src/layouts/Sidebar/styles.module.css
+++ b/src/layouts/Sidebar/styles.module.css
@@ -1,0 +1,8 @@
+.sidebar {
+  border: 1px solid #e5e7eb;
+  border-width: 0 1px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 30px;
+}

--- a/src/services/utils/menuItems.ts
+++ b/src/services/utils/menuItems.ts
@@ -1,0 +1,20 @@
+import { paths } from "./paths";
+
+export const menuItems = {
+  dashboard: {
+    title: "ホーム",
+    linkTo: paths.dashboard,
+  },
+  workouts: {
+    title: "トレーニングを探す",
+    linkTo: paths.workouts,
+  },
+  history: {
+    title: "トレーニング履歴",
+    linkTo: paths.history,
+  },
+  mypage: {
+    title: "マイページ",
+    linkTo: paths.mypage,
+  },
+};

--- a/src/services/utils/paths.ts
+++ b/src/services/utils/paths.ts
@@ -1,0 +1,12 @@
+export const paths = {
+  dashboard: "/dashboard",
+  workouts: "/workouts",
+  workout: "/workout/:id",
+  mypage: "/mypage",
+  customWorkouts: "/custom-workouts",
+  editCustomWorkouts: "/edit/custom-workouts/:id",
+  history: "/history",
+  signin: "/signin",
+  signup: "/signup",
+  changePassword: "/change-password",
+};


### PR DESCRIPTION
## 変更点概要
- Sidebarコンポーネントを追加
- Sidebarで使用する各アイテムの共通コンポーネントを追加
- 全体のレイアウト変更（サイドバー追加に合わせて）

## 残りタスク

- [x] スマホ表示に対応させる
    - [x] サイドバーの内容をヘッダーのメニューから出すようにする
    - [x] レイアウトの調整
- [x] 対象ページがactiveな時にメニューが強調されないので修正
- [x] 各ページのパスを共通の定数などで持つように修正する

## UIの参考
- https://findy-code.io/home
- https://www.codewithantonio.com/

## 実装した画面のスクショ
### スマホ用
メニューが閉じている状態

<img width="498" alt="image" src="https://github.com/khomma0312/fitness-tracker/assets/43176969/065bb154-9558-470a-a6ca-2108df85d2e2">

メニューが開いている状態

<img width="498" alt="image" src="https://github.com/khomma0312/fitness-tracker/assets/43176969/fda7a4c0-cdc4-4270-9e9a-4e8c2c5b393a">


### デスクトップ用
メニューが閉じている状態

<img width="1331" alt="image" src="https://github.com/khomma0312/fitness-tracker/assets/43176969/fc993c6c-5fd0-4779-b2c2-83cbd406ead8">

メニューが開いている状態

<img width="1366" alt="image" src="https://github.com/khomma0312/fitness-tracker/assets/43176969/7032e719-6304-4804-a809-c963a6abd81f">

