### PR TITLE
[add]トレーニング記録ページを追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { CustomWorkouts } from "@/pages/CustomWorkouts";
 import { EditCustomWorkouts } from "@/pages/EditCustomWorkouts";
 import { ChangePassword } from "@/pages/ChangePassword";
 import { History } from "@/pages/History";
+import { AddWorkout } from "@/pages/AddWorkout";
 import { Layout } from "@/Layout";
 import { paths } from "./services/utils/paths";
 
@@ -21,6 +22,7 @@ function App() {
         <Route path={paths.dashboard} element={<Home />} />
         <Route path={paths.workouts} element={<Workouts />} />
         <Route path={paths.workout} element={<Workout />} />
+        <Route path={paths.addWorkout} element={<AddWorkout />} />
         <Route path={paths.mypage} element={<Mypage />} />
         <Route path={paths.customWorkouts} element={<CustomWorkouts />} />
         <Route

--- a/src/components/BurgerMenu/index.tsx
+++ b/src/components/BurgerMenu/index.tsx
@@ -3,6 +3,7 @@ import { useDisclosure } from "@mantine/hooks";
 import { menuItems } from "@/services/utils/menuItems";
 import { HiOutlineHome } from "react-icons/hi";
 import { HiOutlineSearch } from "react-icons/hi";
+import { HiOutlineDocumentPlus } from "react-icons/hi2";
 import { HiOutlineViewList } from "react-icons/hi";
 import { HiOutlineUserCircle } from "react-icons/hi";
 import { SideBarItem } from "../SideBarItem";
@@ -11,6 +12,7 @@ import styles from "./styles.module.css";
 const drawerItems = [
   { ...menuItems.dashboard, icon: <HiOutlineHome size={22} /> },
   { ...menuItems.workouts, icon: <HiOutlineSearch size={22} /> },
+  { ...menuItems.addWorkouts, icon: <HiOutlineDocumentPlus size={22} /> },
   { ...menuItems.history, icon: <HiOutlineViewList size={22} /> },
   { ...menuItems.mypage, icon: <HiOutlineUserCircle size={22} /> },
 ];

--- a/src/layouts/Sidebar/index.tsx
+++ b/src/layouts/Sidebar/index.tsx
@@ -1,6 +1,7 @@
 import { SideBarItem } from "@/components/SideBarItem";
 import { HiOutlineHome } from "react-icons/hi";
 import { HiOutlineSearch } from "react-icons/hi";
+import { HiOutlineDocumentPlus } from "react-icons/hi2";
 import { HiOutlineViewList } from "react-icons/hi";
 import { HiOutlineUserCircle } from "react-icons/hi";
 import styles from "./styles.module.css";
@@ -9,6 +10,7 @@ import { menuItems } from "@/services/utils/menuItems";
 const sidebarItems = [
   { ...menuItems.dashboard, icon: <HiOutlineHome size={22} /> },
   { ...menuItems.workouts, icon: <HiOutlineSearch size={22} /> },
+  { ...menuItems.addWorkouts, icon: <HiOutlineDocumentPlus size={22} /> },
   { ...menuItems.history, icon: <HiOutlineViewList size={22} /> },
   { ...menuItems.mypage, icon: <HiOutlineUserCircle size={22} /> },
 ];

--- a/src/pages/AddWorkout/index.tsx
+++ b/src/pages/AddWorkout/index.tsx
@@ -1,0 +1,3 @@
+export const AddWorkout = () => {
+  return <div>AddWorkout</div>;
+};

--- a/src/services/utils/menuItems.ts
+++ b/src/services/utils/menuItems.ts
@@ -9,6 +9,10 @@ export const menuItems = {
     title: "トレーニングを探す",
     linkTo: paths.workouts,
   },
+  addWorkouts: {
+    title: "トレーニングを記録",
+    linkTo: paths.addWorkout,
+  },
   history: {
     title: "トレーニング履歴",
     linkTo: paths.history,

--- a/src/services/utils/paths.ts
+++ b/src/services/utils/paths.ts
@@ -2,6 +2,7 @@ export const paths = {
   dashboard: "/dashboard",
   workouts: "/workouts",
   workout: "/workout/:id",
+  addWorkout: "/add-workout",
   mypage: "/mypage",
   customWorkouts: "/custom-workouts",
   editCustomWorkouts: "/edit/custom-workouts/:id",


### PR DESCRIPTION
## 変更点概要
- トレーニングを記録するためのページを追加
- ページ追加に伴って、サイドバーとドロワーメニューにトレーニング記録ページへのリンクアイテムを追加

## 残りタスク

- [x] スマホ表示に対応させる
    - [x] レイアウトの調整

## 実装した画面のスクショ
### スマホ用

<img width="499" alt="image" src="https://github.com/khomma0312/fitness-tracker/assets/43176969/50ca2686-ac6c-433e-a5c6-e44975122f83">

### デスクトップ用

<img width="1243" alt="image" src="https://github.com/khomma0312/fitness-tracker/assets/43176969/b99b66f3-e567-4aa8-8b82-353823151440">
